### PR TITLE
Fix caddy config messing up routing

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -5,7 +5,7 @@ network.ryamer.com {
    handle {
       root * /usr/share/caddy/networkui
       encode gzip
-      try_files {path} /index.html
+      try_files {path} /{path}/index.html
       file_server
    }
 }


### PR DESCRIPTION
Previous settings was routing every page into index.html, which was causing hydration errros. This should fix it.